### PR TITLE
Add cjs and mjs to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,6 @@ insert_final_newline = true
 # unset will result in using the editor default
 [*.md]
 trim_trailing_whitespace = false
-[*.{js,jsx,ts,d.ts,css,html}]
+[*.{cjs,mjs,js,jsx,ts,d.ts,css,html}]
 indent_style = tab
 indent_size = unset


### PR DESCRIPTION
This PR adds `cjs` and `mjs` to editorconfig to ensure that tabs are used in those extensions.