### PR TITLE
Update support for Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,10 @@ workflows:
     # Inside the workflow, you define the jobs you want to run.
     jobs:
       - node/test:
-          # This is the node version to use for the `cimg/node` tag
-          # Relevant tags can be found on the CircleCI Developer Hub
-          # https://circleci.com/developer/images/image/cimg/node
-          version: '16.10'
+          matrix:
+            parameters:
+              version:
+                - '16.15'
+                - '18.0'
           # If you are using yarn, change the line below from "npm" to "yarn"
           pkg-manager: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "4.6.4"
       },
       "engines": {
-        "node": "^16.0.0"
+        "node": "^16.0.0 || ^18.0.0"
       },
       "peerDependencies": {
         "prettier": ">=2.5.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/STORIS/prettier-config#readme",
   "engines": {
-    "node": "^16.0.0"
+    "node": "^16.0.0 || ^18.0.0"
   },
   "peerDependencies": {
     "prettier": ">=2.5.0"


### PR DESCRIPTION
This PR augments the `engines` property of `package.json` to support `^18.0.0` as well as `^16.0.0`.  The CI configuration was adjusted to run tests against both `16.15.0` and `18.0.0`.  Note: The circle [tags](https://circleci.com/developer/images/image/cimg/node) don't appear to have been updated to support `18.1.0` yet.