### PR TITLE
Prepare for release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2022-05-13
+
+This release changes the version to 1.0.0 only so it can more easily align with semantic versioning in the future. It does not contain any breaking changes.
+
+### Added
+
+- Update engines to indicate Node 18 support ([#75](https://github.com/STORIS/prettier-config/pull/75))
+
 ## [0.0.2] - 2022-01-19
 
 No changes; only a version bump
@@ -17,6 +25,7 @@ No changes; only a version bump
 
 - Initial release
 
-[unreleased]: https://github.com/storis/prettier-config/compare/0.0.2...HEAD
+[unreleased]: https://github.com/storis/prettier-config/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/storis/prettier-config/compare/0.0.2...1.0.0
 [0.0.2]: https://github.com/storis/prettier-config/compare/0.0.1...0.0.2
 [0.0.1]: https://github.com/storis/prettier-config/releases/tag/0.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@storis/prettier-config",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@storis/prettier-config",
-      "version": "0.0.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@storis/eslint-config": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storis/prettier-config",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "STORIS prettier configuration",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR prepares for the 1.0.0 release by bumping the version and updating the CHANGELOG.